### PR TITLE
Add possible requests to API responses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
     "extends": "airbnb-base",
     "rules": {
+        "no-underscore-dangle": 0,
     }
 };

--- a/api/helpers/mapReturnObjects.js
+++ b/api/helpers/mapReturnObjects.js
@@ -1,0 +1,48 @@
+const returnMethods = require('../helpers/returnMethods');
+
+const requestURLMapping = {};
+
+requestURLMapping.allRecipes = (req, recipes) => {
+  const newRecipes = [];
+  recipes.map((entry) => {
+    const item = { ...entry };
+    item._doc.requests = {
+      getRecipe: returnMethods.getSingleRecipe(req, item._doc._id),
+      editRecipe: returnMethods.editRecipe(req, item._doc._id),
+      deleteRecipe: returnMethods.deleteRecipe(req, item._doc._id),
+    };
+    newRecipes.push(item._doc);
+    return item._doc;
+  });
+  return newRecipes;
+};
+
+requestURLMapping.singleRecipes = (req, recipes) => {
+  const item = { ...recipes };
+  item._doc.requests = {
+    getAllRecipes: returnMethods.getAllMethod(req),
+    editRecipe: returnMethods.editRecipe(req, item._doc._id),
+    deleteRecipe: returnMethods.deleteRecipe(req, item._doc._id),
+  };
+  return item._doc;
+};
+
+requestURLMapping.addRecipe = (req, recipeId) => {
+  const requests = {
+    getAllRecipes: returnMethods.getAllMethod(req),
+    getSingleRecipe: returnMethods.getSingleRecipe(req, recipeId),
+    editRecipe: returnMethods.editRecipe(req, recipeId),
+    deleteRecipe: returnMethods.deleteRecipe(req, recipeId),
+  };
+  return requests;
+};
+
+requestURLMapping.startMethods = (req) => {
+  const requests = {
+    getAllRecipes: returnMethods.getAllMethod(req),
+    addRecipe: returnMethods.addRecipe(req),
+  };
+  return requests;
+};
+
+module.exports = requestURLMapping;

--- a/api/helpers/returnMethods.js
+++ b/api/helpers/returnMethods.js
@@ -1,0 +1,54 @@
+const url = require('url');
+
+const returnMethods = {};
+const sampleData = {
+  title: 'Test',
+  time: 10,
+  ingredients: 'noodles',
+  instructions: {
+    1: 'Boil water',
+    2: 'Place noodle in water',
+    3: 'Drain water',
+  },
+  servings: 2,
+};
+
+const path = (req, originalUrl = '') => url.format({
+  protocol: req.protocol,
+  host: req.get('host'),
+  pathname: originalUrl,
+});
+
+returnMethods.getAllMethod = req => ({
+  method: 'GET',
+  description: 'Get all Recipes',
+  path: `${path(req)}/recipes`,
+});
+
+returnMethods.getSingleRecipe = (req, recipeId) => ({
+  method: 'Get',
+  description: 'Get this single Recipe',
+  path: path(req, `recipes/${recipeId}`),
+});
+
+returnMethods.editRecipe = (req, recipeId) => ({
+  method: 'Patch',
+  description: 'Edit this recipe',
+  path: path(req, `recipes/${recipeId}`),
+  sampleData,
+});
+
+returnMethods.deleteRecipe = (req, recipeId) => ({
+  method: 'Delete',
+  description: 'Delete this recipe',
+  path: path(req, `recipes/${recipeId}`),
+});
+
+returnMethods.addRecipe = req => ({
+  method: 'Post',
+  description: 'Add a recipe',
+  path: path(req, 'recipes'),
+  sampleData,
+});
+
+module.exports = returnMethods;

--- a/api/models/recipes.js
+++ b/api/models/recipes.js
@@ -16,6 +16,17 @@ const recipeSchema = mongoose.Schema({
     max: [260, 'Maximum time of 260 mins'],
     required: [true, 'Time is required'],
   },
+  instructions: {
+    type: Map,
+    of: String,
+    required: [true, 'Instructions are required'],
+  },
+  servings: {
+    type: Number,
+    min: [1, 'Minimum of 1 serving required'],
+    max: [260, 'Maximum of 25 servings is allowed'],
+    required: [true, 'Please enter the number of servings required'],
+  },
 });
 
 module.exports = mongoose.model('RecipeModel', recipeSchema);

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const morgan = require('morgan');
 const bodyParser = require('body-parser');
 
 const recipeRoutes = require('./api/routes/recipes');
+const returnURLMapping = require('./api/helpers/mapReturnObjects');
 
 const app = express();
 
@@ -20,6 +21,12 @@ app.use((req, res, next) => {
   }
   // Call next at end of middleware so we unblock the incoming request due to the OPTIONS request
   next();
+});
+
+app.get('/', (req, res) => {
+  res.status(200).json({
+    requests: returnURLMapping.startMethods(req),
+  });
 });
 
 app.use('/recipes', recipeRoutes);


### PR DESCRIPTION
#### What does this PR do?
- Add the possible requests to the responses the API provides for easier understanding

#### How should this be manually tested?
- Run the server `npm run dev`
- On port `3000` or any other specified port
- Run a `GET` request and you should get some starter requests as attached in the image at the bottom

#### Screenshots
<img width="1003" alt="screenshot 2019-01-21 at 11 41 08" src="https://user-images.githubusercontent.com/33119403/51463043-42c28680-1d73-11e9-8479-90d733e7b8de.png">
